### PR TITLE
php >= 8.0 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "5.3"
+          - "8.0"
+          - "8.1"
 
         dependencies:
           - "highest"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,50 @@
+name: "Continuous Integration"
+
+on:
+  - pull_request
+  - push
+
+env:
+  COMPOSER_ROOT_VERSION: 1.99
+
+jobs:
+  tests:
+    name: "Tests"
+
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        php-version:
+          - "5.3"
+
+        dependencies:
+          - "highest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          ini-values: zend.assertions=1
+
+      - name: "Get composer cache directory"
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: "Cache dependencies"
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-
+
+      - name: "Install highest dependencies"
+        run: "composer update --no-interaction --no-progress"
+
+      - name: "Run tests"
+        timeout-minutes: 3
+        run: "vendor/bin/phpunit"

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ composer.phar
 /build/
 phpunit.xml
 TODO
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ Feel free to comment, send pull requests and patches...
 Basic usage ~ *standalone*
 -----------
 ```php
-use Apix\Log;
 
-$urgent_logger = new Logger\Mail('franck@foo.bar');
+$urgent_logger = new Apix\Log\Logger\Mail('franck@foo.bar');
 $urgent_logger->setMinLevel('critical');   // catch logs >= to `critical`
 ```
 
@@ -49,7 +48,7 @@ Advanced usage ~ *multi-logs dispatcher*
 --------------
 Lets create an additional logger with purpose of catching log entries that have a severity level of `warning` or more -- see the [log levels](#log-levels) for the order.
 ```php
-$app_logger = new Logger\File('/var/log/apix_app.log');
+$app_logger = new Apix\Log\Logger\File('/var/log/apix_app.log');
 $app_logger->setMinLevel('warning')  // intercept logs that are >= `warning`
            ->setCascading(false)     // don't propagate to further buckets
            ->setDeferred(true);      // postpone/accumulate logs processing
@@ -59,13 +58,13 @@ $app_logger->setMinLevel('warning')  // intercept logs that are >= `warning`
 Now, lets create a main logger object and inject the two previous loggers.
 ```php
 // The main logger object (injecting an array of loggers)
-$logger = new Logger( array($urgent_logger, $app_logger) );
+$logger = new Apix\Log\Logger( array($urgent_logger, $app_logger) );
 ```
 Lets create an additional logger -- just for development/debug purposes.
 ```php
 if(DEBUG) {
   // Bucket for the remaining logs -- i.e. `notice`, `info` and `debug`
-  $dev_logger = new Logger\Stream(); // default to screen without output buffer  
+  $dev_logger = new Apix\Log\Logger\Stream(); // default to screen without output buffer
   // $dev_logger = new Logger\File('/tmp/apix_debug.log'); 
   $dev_logger->setMinLevel('debug');
 

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,11 @@
         "irc": "irc://irc.freenode.org/ouarz"
     },
     "require": {
-        "php": ">=5.3",
-        "psr/log": "~1.0"
+        "php": ">=8.0",
+        "psr/log": "^2.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0|^5.0",
-        "satooshi/php-coveralls": "~0.7.1"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "suggest": {
         "PHPMailer/apix-log-phpmailer": "Allow sending log messages via PHPMailer",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,34 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    colors="false"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    syntaxCheck="false"
-    bootstrap="tests/bootstrap.php"
->
-    <testsuites>
-        <testsuite name="Apix Log Unit Tests">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>build</directory>
-                <directory>tests</directory>
-                <directory>vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>build</directory>
+      <directory>tests</directory>
+      <directory>vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Apix Log Unit Tests">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>
-
 <!-- vim: set tabstop=4 shiftwidth=4 expandtab: -->

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -138,7 +138,7 @@ class Logger extends AbstractLogger
     {
         return usort(
             $this->buckets, function ($a, $b) {
-                return $a->getMinLevel() > $b->getMinLevel();
+                return $a->getMinLevel() - $b->getMinLevel();
             }
         );
     }

--- a/src/Logger/AbstractLogger.php
+++ b/src/Logger/AbstractLogger.php
@@ -12,6 +12,7 @@ namespace Apix\Log\Logger;
 
 use Psr\Log\AbstractLogger as PsrAbstractLogger;
 use Psr\Log\InvalidArgumentException;
+use Stringable;
 use Apix\Log\LogEntry;
 use Apix\Log\LogFormatter;
 
@@ -95,7 +96,7 @@ abstract class AbstractLogger extends PsrAbstractLogger
     /**
      * {@inheritdoc}
      */
-    public function log($level, $message, array $context = array())
+    public function log($level, Stringable|string $message, array $context = array()) : void
     {
         $entry = new LogEntry($level, $message, $context);
         $entry->setFormatter($this->getLogFormatter());
@@ -181,6 +182,15 @@ abstract class AbstractLogger extends PsrAbstractLogger
     }
 
     /**
+     * Get cascading property
+     * @return bool
+     */
+    public function cascading()
+    {
+        return $this->cascading;
+    }
+
+    /**
      * Sets wether to enable/disable log deferring.
      *
      * @param  bool $bool
@@ -191,6 +201,15 @@ abstract class AbstractLogger extends PsrAbstractLogger
         $this->deferred = (boolean) $bool;
 
         return $this;
+    }
+
+    /**
+     * Get deferred property
+     * @return bool
+     */
+    public function deferred()
+    {
+        return $this->deferred;
     }
 
     /**

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -14,7 +14,7 @@ use Apix\Log\tests\Logger\TestCase;
 
 use Apix\Log\Logger;
 
-class ReadmeTest extends \PHPUnit_Framework_TestCase
+class ReadmeTest extends \PHPUnit\Framework\TestCase
 {
 
     /**
@@ -119,5 +119,4 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
             $this->getLogs($debug_logger)
         );
     }
-
 }

--- a/tests/InterfacesTest.php
+++ b/tests/InterfacesTest.php
@@ -44,16 +44,16 @@ class MyJsonFormatter extends LogFormatter
     }
 }
 
-class InterfacesTest extends \PHPUnit_Framework_TestCase
+class InterfacesTest extends \PHPUnit\Framework\TestCase
 {
     protected $logger;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->logger = new StandardOutput();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         unset($this->logger);
     }

--- a/tests/Logger/ErrorLogTest.php
+++ b/tests/Logger/ErrorLogTest.php
@@ -12,12 +12,11 @@ namespace Apix\Log\tests\Logger;
 
 use Apix\Log\Logger;
 
-class ErrorLogTest extends TestCase
+class ErrorLogTest extends \PHPUnit\Framework\TestCase
 {
+    protected $dest = 'test';
 
-    // protected $dest = '/dev/stdout';
-
-    protected function setUp()
+    protected function setUp() : void
     {
         // HHVM support
         // @see: https://github.com/facebook/hhvm/issues/3558
@@ -29,19 +28,22 @@ class ErrorLogTest extends TestCase
         ini_set('error_log', $this->dest);
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         if (file_exists($this->dest)) {
             unlink($this->dest);
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getLogger()
+    public function testWrite()
     {
-        return new Logger\ErrorLog();
-    }
+        $logger = new Logger\ErrorLog();
 
+        $message = 'test log';
+        $logger->debug($message);
+
+        $content = file_get_contents($this->dest);
+
+        $this->assertStringContainsString($message, $content);
+    }
 }

--- a/tests/Logger/FileTest.php
+++ b/tests/Logger/FileTest.php
@@ -20,16 +20,9 @@ class FileTest extends \PHPUnit\Framework\TestCase
     protected function tearDown() : void
     {
         if (file_exists($this->dest)) {
+            chmod($this->dest, 0777);
             unlink($this->dest);
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getLogger()
-    {
-        return new Logger\File($this->dest);
     }
 
     public function testThrowsInvalidArgumentExceptionWhenFileCannotBeCreated()
@@ -42,17 +35,13 @@ class FileTest extends \PHPUnit\Framework\TestCase
 
     public function testThrowsInvalidArgumentExceptionWhenNotWritable()
     {
-        if (strtoupper(substr(php_uname('s'), 0, 3)) === 'WIN') {
-            $file = 'C:\Windows\.';
-        } else {
-            $file = '.';
-        }
+        touch($this->dest);
+        chmod($this->dest, 0000);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Log file \"{$file}\" is not writable");
+        $this->expectExceptionMessage("Log file \"{$this->dest}\" is not writable");
         $this->expectExceptionCode(2);
 
-
-        new Logger\File($file);
+        new Logger\File($this->dest);
     }
 }

--- a/tests/Logger/FileTest.php
+++ b/tests/Logger/FileTest.php
@@ -11,11 +11,13 @@
 namespace Apix\Log\tests\Logger;
 
 use Apix\Log\Logger;
+use Psr\Log\InvalidArgumentException;
 
-class FileTest extends TestCase
+class FileTest extends \PHPUnit\Framework\TestCase
 {
+    protected $dest = 'test';
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         if (file_exists($this->dest)) {
             unlink($this->dest);
@@ -30,24 +32,27 @@ class FileTest extends TestCase
         return new Logger\File($this->dest);
     }
 
-    /**
-     * @expectedException Psr\Log\InvalidArgumentException
-     * @expectedExceptionMessage Log file "" cannot be created
-     * @expectedExceptionCode 1
-     */
     public function testThrowsInvalidArgumentExceptionWhenFileCannotBeCreated()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Log file "" cannot be created');
+        $this->expectExceptionCode(1);
         new Logger\File(null);
     }
 
-    /**
-     * @expectedException Psr\Log\InvalidArgumentException
-     * @expectedExceptionMessage Log file "/" is not writable
-     * @expectedExceptionCode 2
-     */
     public function testThrowsInvalidArgumentExceptionWhenNotWritable()
     {
-        new Logger\File('/');
-    }
+        if (strtoupper(substr(php_uname('s'), 0, 3)) === 'WIN') {
+            $file = 'C:\Windows\.';
+        } else {
+            $file = '.';
+        }
 
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Log file \"{$file}\" is not writable");
+        $this->expectExceptionCode(2);
+
+
+        new Logger\File($file);
+    }
 }

--- a/tests/Logger/MailTest.php
+++ b/tests/Logger/MailTest.php
@@ -8,34 +8,31 @@
  * @license http://opensource.org/licenses/BSD-3-Clause  New BSD License
  */
 
-namespace Apix\Log\tests\Logger;
+namespace Apix\Log;
 
-use Apix\Log\Logger;
+use Apix\Log;
+use Psr\Log\InvalidArgumentException;
+use PHPUnit\Framework\Assert;
 
-class MailTest extends \PHPUnit_Framework_TestCase
+class MailTest extends \PHPUnit\Framework\TestCase
 {
-
-    /**
-     * @expectedException Psr\Log\InvalidArgumentException
-     * @expectedExceptionMessage "" is an invalid email address
-     */
     public function testThrowsInvalidArgumentExceptionWhenNull()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"" is an invalid email address');
         new Logger\Mail(null);
     }
 
-    /**
-     * @expectedException Psr\Log\InvalidArgumentException
-     * @expectedExceptionMessage "foo" is an invalid email address
-     */
     public function testThrowsInvalidArgumentException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"foo" is an invalid email address');
         new Logger\Mail('foo');
     }
 
     public function testConstructor()
     {
         new Logger\Mail('foo@bar.com', 'CC: some@somewhere.com');
+        $this->assertTrue(true);
     }
-
 }

--- a/tests/Logger/RuntimeTest.php
+++ b/tests/Logger/RuntimeTest.php
@@ -9,18 +9,19 @@
 
 namespace Apix\Log\tests\Logger;
 
+use Apix\Log\tests\Logger\TestCase;
 use Apix\Log\Logger;
 
-class RuntimeTest extends TestCase
+class RuntimeTest extends \PHPUnit\Framework\TestCase
 {
     protected $logger;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->logger = new Logger\Runtime();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         unset($this->logger);
     }
@@ -30,7 +31,7 @@ class RuntimeTest extends TestCase
      */
     public function getLogs()
     {
-        return self::normalizeLogs($this->logger->getItems());
+        return TestCase::normalizeLogs($this->logger->getItems());
     }
 
     /**
@@ -52,5 +53,4 @@ class RuntimeTest extends TestCase
             $this->getLogs()
         );
     }
-
 }

--- a/tests/Logger/StreamTest.php
+++ b/tests/Logger/StreamTest.php
@@ -11,19 +11,20 @@
 namespace Apix\Log\tests\Logger;
 
 use Apix\Log\Logger;
+use Psr\Log\InvalidArgumentException;
 
-class StreamTest extends TestCase
+class StreamTest extends \PHPUnit\Framework\TestCase
 {
     protected $dest = 'php://memory';
     protected $stream, $logger;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->stream = fopen($this->dest, 'a');
         $this->logger = new Logger\Stream($this->stream);
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         unset($this->logger, $this->stream);
     }
@@ -57,24 +58,20 @@ class StreamTest extends TestCase
     //     $this->assertEquals($this->logger, $logger);
     // }
 
-    /**
-     * @expectedException Psr\Log\InvalidArgumentException
-     * @expectedExceptionMessage The stream "" cannot be created or opened
-     */
     public function testThrowsInvalidArgumentExceptionWhenFileCannotBeCreated()
     {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('Path cannot be empty');
         new Logger\Stream(null);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The stream resource has been __destruct() too early
-     */
     public function testThrowsLogicException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The stream resource has been __destruct() too early');
+
         $logger = new Logger\Stream;
         $logger->__destruct();
         $logger->debug('foo');
     }
-
 }

--- a/tests/Logger/TestCase.php
+++ b/tests/Logger/TestCase.php
@@ -10,9 +10,9 @@
 
 namespace Apix\Log\tests\Logger;
 
-use Psr\Log\Test\LoggerInterfaceTest;
+use Psr\Log\LoggerInterface;
 
-abstract class TestCase extends LoggerInterfaceTest
+abstract class TestCase implements LoggerInterface
 {
     protected $dest = 'build/apix-unit-test-logger.log';
 

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -10,25 +10,22 @@
 
 namespace Apix\Log;
 
+use Psr\Log\InvalidArgumentException;
 use Psr\Log\LogLevel;
+use PHPUnit\Framework\Assert;
 
-class LoggerTest extends \PHPUnit_Framework_TestCase
+class LoggerTest extends \PHPUnit\Framework\TestCase
 {
     protected $logger;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->logger = new Logger();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         unset($this->logger);
-    }
-
-    protected function _getPrivateAttribute($prop)
-    {
-        return \PHPUnit_Framework_Assert::readAttribute($this->logger, $prop);
     }
 
     /**
@@ -40,12 +37,10 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(3, Logger::getLevelCode('error'));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage "stdClass" must interface "Apix\Log\Logger\LoggerInterface"
-     */
     public function testConstructorThrowsInvalidArgumentException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"stdClass" must interface "Apix\Log\Logger\LoggerInterface"');
         new Logger(array( new \StdClass() ));
     }
 
@@ -66,11 +61,9 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->logger->critical('test crit');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetLevelCodeThrows()
     {
+        $this->expectException(InvalidArgumentException::class);
         Logger::getLevelCode('non-existant');
     }
 
@@ -79,11 +72,9 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('error', Logger::getPsrLevelName(LogLevel::ERROR));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetPsrLevelNameWillThrows()
     {
+        $this->expectException(InvalidArgumentException::class);
         Logger::getPsrLevelName('non-existant');
     }
 
@@ -210,12 +201,11 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetCascading()
     {
-        $this->assertTrue(
-            $this->_getPrivateAttribute("cascading"),
-            "The 'cascading' propertie should be True by default"
+        $this->assertTrue($this->logger->cascading(),
+            "The 'cascading' property should be True by default"
         );
         $this->logger->setCascading(false);
-        $this->assertFalse($this->_getPrivateAttribute("cascading"));
+        $this->assertFalse($this->logger->cascading());
     }
 
     public function testCascading()
@@ -244,11 +234,11 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     public function testSetDeferred()
     {
         $this->assertFalse(
-            $this->_getPrivateAttribute('deferred'),
-            "The 'deferred' propertie should be False by default"
+            $this->logger->deferred(),
+            "The 'deferred' property should be False by default"
         );
         $this->logger->setDeferred(true);
-        $this->assertTrue($this->_getPrivateAttribute('deferred'));
+        $this->assertTrue($this->logger->deferred());
     }
 
     public function testDeferring()
@@ -289,11 +279,10 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
 
         $this->logger->setMinLevel('alert', true);
         $this->assertEquals(1, $this->logger->getMinLevel());
-        $this->assertTrue($this->_getPrivateAttribute("cascading"));
+        $this->assertTrue($this->logger->cascading());
 
         $this->logger->interceptAt('warning', true);
         $this->assertEquals(4, $this->logger->getMinLevel());
-        $this->assertFalse($this->_getPrivateAttribute("cascading"));
+        $this->assertFalse($this->logger->cascading());
     }
-
 }


### PR DESCRIPTION
Thanks for a great logger that I just discovered when I was looking at monolog alternatives. As I'm going to use it on php 8.1, I've spent a few hours updating the whole project for that purpose.

Main changes:
- use psr/log 2 or 3
- use phpunit 8 or 9
- fix usort() returning bool from comparison function is deprecated
- update tests for phpunit 8/9
- update readme examples for php 8