### PR TITLE
Add get log destination Add check log empty

### DIFF
--- a/src/Logger/AbstractLogger.php
+++ b/src/Logger/AbstractLogger.php
@@ -75,6 +75,12 @@ abstract class AbstractLogger extends PsrAbstractLogger
     protected $options = array();
 
     /**
+     * Whether or not log is empty.
+     * @var bool
+     */
+    protected $empty = true;
+
+    /**
      * Gets the named level code.
      *
      * @param  string $level_name The name of a PSR-3 level.
@@ -111,6 +117,10 @@ abstract class AbstractLogger extends PsrAbstractLogger
      */
     public function process(LogEntry $log)
     {
+        if ($this->empty) {
+            $this->empty = false;
+        }
+
         if ($this->deferred) {
             $this->deferred_logs[] = $log;
         } else {
@@ -276,7 +286,7 @@ abstract class AbstractLogger extends PsrAbstractLogger
      * @return LogFormatter
      */
     public function getLogFormatter()
-    {    
+    {
         if(!$this->log_formatter) {
             $this->setLogFormatter(new LogFormatter);
         }
@@ -296,4 +306,13 @@ abstract class AbstractLogger extends PsrAbstractLogger
         }
     }
 
+    /**
+     * Check if log is empty
+     *
+     * @return bool
+     */
+    public function isEmpty() : bool
+    {
+        return $this->empty;
+    }
 }

--- a/src/Logger/ErrorLog.php
+++ b/src/Logger/ErrorLog.php
@@ -77,4 +77,13 @@ class ErrorLog extends AbstractLogger implements LoggerInterface
         );
     }
 
+    /**
+     * Get log destination
+     *
+     * @return string|null
+     */
+    public function getDestination() : string|null
+    {
+        return $this->destination;
+    }
 }

--- a/src/Logger/File.php
+++ b/src/Logger/File.php
@@ -19,7 +19,6 @@ use Psr\Log\InvalidArgumentException;
  */
 class File extends ErrorLog
 {
-
     /**
      * Constructor.
      *
@@ -42,5 +41,4 @@ class File extends ErrorLog
         $this->destination = $file;
         $this->type = static::FILE;
     }
-
 }


### PR DESCRIPTION
I've added code to check if the log is empty and where the log file is. Here's how I use it:

```php
    foreach ($container['logger']->getBuckets() as $bucket) {
        // check not empty and at least warning (4)
        if (get_class($bucket) === 'Apix\\Log\\Logger\\File' && !$bucket->isEmpty()) {
            if (!$file = $bucket->getDestination()) {
                continue;
            }

            // get log content
            $content = file_get_contents($file, false);

           // send log by email
    }
```