### PR TITLE
Deferred logs improvements

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -76,7 +76,17 @@ class Logger extends AbstractLogger
     }
 
     /**
-     * Checks if any log bucket can hanle the given code.
+     * Flush deferred logs
+     */
+    public function flushDeferredLogs()
+    {
+        foreach ($this->buckets as $bucket) {
+            $bucket->flushDeferredLogs();
+        }
+    }
+
+    /**
+     * Checks if any log bucket can handle the given code.
      *
      * @param int $level_code
      *
@@ -131,7 +141,7 @@ class Logger extends AbstractLogger
     /**
      * Sorts the log buckets, prioritizes top-down by minimal level.
      * Beware: Exisiting level will be in FIFO order.
-     * 
+     *
      * @return bool Returns TRUE on success or FALSE on failure.
      */
     protected function sortBuckets()

--- a/src/Logger/ErrorLog.php
+++ b/src/Logger/ErrorLog.php
@@ -61,12 +61,12 @@ class ErrorLog extends AbstractLogger implements LoggerInterface
     /**
      * {@inheritDoc}
      */
-    public function write(LogEntry $log)
+    public function write(LogEntry|string $log)
     {
         $message = (string) $log;
 
         if(!$this->deferred && $this->type == self::FILE) {
-            $message .= $log->formatter->separator;
+            $message = $log->formatter->separator . $message . $log->formatter->separator;
         }
 
         return error_log(
@@ -76,5 +76,4 @@ class ErrorLog extends AbstractLogger implements LoggerInterface
             $this->headers
         );
     }
-
 }

--- a/src/Logger/File.php
+++ b/src/Logger/File.php
@@ -42,5 +42,4 @@ class File extends ErrorLog
         $this->destination = $file;
         $this->type = static::FILE;
     }
-
 }

--- a/src/Logger/LoggerInterface.php
+++ b/src/Logger/LoggerInterface.php
@@ -39,9 +39,9 @@ interface LoggerInterface
     /**
      * Writes the given log entry.
      *
-     * @param  LogEntry $log
+     * @param  LogEntry|string $log
      * @return bool Wether the log entry was successfully written or not.
      */
-    public function write(LogEntry $log);
+    public function write(LogEntry|string $log);
 
 }

--- a/src/Logger/Nil.php
+++ b/src/Logger/Nil.php
@@ -24,7 +24,7 @@ class Nil extends AbstractLogger implements LoggerInterface
     /**
      * {@inheritDoc}
      */
-    public function write(LogEntry $log)
+    public function write(LogEntry|string $log)
     {
         return false;
     }

--- a/src/Logger/Runtime.php
+++ b/src/Logger/Runtime.php
@@ -28,7 +28,7 @@ class Runtime extends AbstractLogger implements LoggerInterface
     /**
      * {@inheritDoc}
      */
-    public function write(LogEntry $log)
+    public function write(LogEntry|string $log)
     {
         $this->items[] = (string) $log;
     }

--- a/src/Logger/Stream.php
+++ b/src/Logger/Stream.php
@@ -51,7 +51,7 @@ class Stream extends AbstractLogger implements LoggerInterface
     /**
      * {@inheritDoc}
      */
-    public function write(LogEntry $log)
+    public function write(LogEntry|string $log)
     {
         if (!is_resource($this->stream)) {
             throw new \LogicException(

--- a/tests/InterfacesTest.php
+++ b/tests/InterfacesTest.php
@@ -20,7 +20,7 @@ use Apix\Log\Logger\LoggerInterface;
  */
 class StandardOutput extends AbstractLogger implements LoggerInterface
 {
-    public function write(LogEntry $log)
+    public function write(LogEntry|string $log)
     {
         echo $log;
     }


### PR DESCRIPTION
Deferring logs writing to file has a huge positive impact #9 on speed however it's a bit riskier because if the script terminates in an unclean way, we lose the whole log.

In this pull request, I've added:

- Add possibility to manually flush deferred logs
- Fix deferred logs would show up as notice
- Fix deferred logs would not have new line separator
- Add flush deferred trigger (flush when x number of logs were stored)

Here's how it looks

```php
    $info = (new File(ConfigBase::logFile(), false))
        ->setMinLevel('info')
        // propagate to other loggers
        ->setCascading(true)
        // postpone/accumulate logs processing
        ->setDeferred(true)
        // automatically flush when the trigger is reached
        ->setDeferredTrigger(100);
```