### PR TITLE
Add minimum level logged

### DIFF
--- a/src/Logger/AbstractLogger.php
+++ b/src/Logger/AbstractLogger.php
@@ -75,6 +75,12 @@ abstract class AbstractLogger extends PsrAbstractLogger
     protected $options = array();
 
     /**
+     * Minimum level logged
+     * @var int
+     */
+    protected $min_level_logged = 7;
+
+    /**
      * Gets the named level code.
      *
      * @param  string $level_name The name of a PSR-3 level.
@@ -111,6 +117,10 @@ abstract class AbstractLogger extends PsrAbstractLogger
      */
     public function process(LogEntry $log)
     {
+        if ($this->min_level_logged > $log->level_code) {
+            $this->min_level_logged = $log->level_code;
+        }
+
         if ($this->deferred) {
             $this->deferred_logs[] = $log;
         } else {
@@ -235,9 +245,9 @@ abstract class AbstractLogger extends PsrAbstractLogger
                 },
                 $this->deferred_logs
             );
-            
+
             $formatter = $this->getLogFormatter();
-            
+
             $messages = implode($formatter->separator, $messages);
 
             $entries = new LogEntry('notice', $messages);
@@ -276,7 +286,7 @@ abstract class AbstractLogger extends PsrAbstractLogger
      * @return LogFormatter
      */
     public function getLogFormatter()
-    {    
+    {
         if(!$this->log_formatter) {
             $this->setLogFormatter(new LogFormatter);
         }
@@ -296,4 +306,13 @@ abstract class AbstractLogger extends PsrAbstractLogger
         }
     }
 
+    /**
+     * Gets min level logged
+     *
+     * @return int
+     */
+    public function getMinLevelLogged() : int
+    {
+        return $this->min_level_logged;
+    }
 }

--- a/src/Logger/ErrorLog.php
+++ b/src/Logger/ErrorLog.php
@@ -50,7 +50,7 @@ class ErrorLog extends AbstractLogger implements LoggerInterface
     /**
      * Constructor.
      * @param string|null $file The filename to log messages to.
-     * @param integer     $type The messag/delivery type.
+     * @param integer     $type The message/delivery type.
      */
     public function __construct($file = null, $type = self::PHP)
     {


### PR DESCRIPTION
And here a way to get the minimum level that was logged. Here's how I use it:

```php
    foreach ($container['logger']->getBuckets() as $bucket) {
        // check not empty and at least warning (4)
        if (get_class($bucket) === 'Apix\\Log\\Logger\\File' && !$bucket->isEmpty() && $bucket->getMinLevelLogged() <= 4) {
            // get log content
            $content = file_get_contents($bucket->getDestination(), false);

            mail_log($content);
        }
    }
```